### PR TITLE
feat: add website scaffolding crew

### DIFF
--- a/src/sprint_3/config/agents.yaml
+++ b/src/sprint_3/config/agents.yaml
@@ -1,19 +1,38 @@
-researcher:
-  role: >
-    {topic} Senior Data Researcher
-  goal: >
-    Uncover cutting-edge developments in {topic}
-  backstory: >
-    You're a seasoned researcher with a knack for uncovering the latest
-    developments in {topic}. Known for your ability to find the most relevant
-    information and present it in a clear and concise manner.
+# agents.yaml - agent definitions for the Sprint 3 website mimicker crew
 
-reporting_analyst:
-  role: >
-    {topic} Reporting Analyst
-  goal: >
-    Create detailed reports based on {topic} data analysis and research findings
-  backstory: >
-    You're a meticulous analyst with a keen eye for detail. You're known for
-    your ability to turn complex data into clear and concise reports, making
-    it easy for others to understand and act on the information you provide.
+site_analyzer:
+  role: "Layout Analyst"
+  goal: "Study ${TARGET_URL} and produce high level layout specifications."
+  backstory: "Frontend designer skilled in reverse engineering UX flows."
+  tools: ["serper", "file_writer"]
+
+ui_architect:
+  role: "UI Architect"
+  goal: "Transform layout specs into a Next.js route and component plan."
+  backstory: "Architect who plans scalable React structures."
+  tools: []
+
+component_generator:
+  role: "Component Generator"
+  goal: "Create accessible Next.js + Tailwind pages and components."
+  backstory: "Efficient engineer producing clean, commented code."
+  tools: ["file_writer"]
+
+data_modeler:
+  role: "Data Modeler"
+  goal: "Provide TypeScript types and mock API routes."
+  backstory: "Type-safe full-stack developer."
+  tools: ["file_writer"]
+
+commerce_flow_engineer:
+  role: "Commerce Flow Engineer"
+  goal: "Implement cart and checkout logic with a finite state machine."
+  backstory: "Specialist in e-commerce flows."
+  tools: ["file_writer"]
+
+qa_validator:
+  role: "QA Validator"
+  goal: "Explain how to lint, typecheck and build the project."
+  backstory: "Reliability engineer ensuring code quality."
+  tools: []
+

--- a/src/sprint_3/config/tasks.yaml
+++ b/src/sprint_3/config/tasks.yaml
@@ -1,17 +1,66 @@
-research_task:
-  description: >
-    Conduct a thorough research about {topic}
-    Make sure you find any interesting and relevant information given
-    the current year is {current_year}.
-  expected_output: >
-    A list with 10 bullet points of the most relevant information about {topic}
-  agent: researcher
+# tasks.yaml - task specifications for the Sprint 3 crew
 
-reporting_task:
-  description: >
-    Review the context you got and expand each topic into a full section for a report.
-    Make sure the report is detailed and contains any and all relevant information.
-  expected_output: >
-    A fully fledged report with the main topics, each with a full section of information.
-    Formatted as markdown without '```'
-  agent: reporting_analyst
+analyze_site:
+  agent: site_analyzer
+  description: |
+    Review the target site at ${TARGET_URL} focusing only on layout and user flow.
+    Summarize the structure and interactions.
+    WRITE files using file_writer:
+      - src/sprint_3/.artifacts/LayoutSpec.json
+      - src/sprint_3/.artifacts/ComponentMap.json
+  expected_output: "LayoutSpec.json and ComponentMap.json created in .artifacts."
+
+plan_routes:
+  agent: ui_architect
+  description: |
+    Using LayoutSpec.json and ComponentMap.json, propose a Next.js route plan
+    and component hierarchy. No files are written.
+
+scaffold_pages:
+  agent: component_generator
+  async: true
+  description: |
+    Convert the route plan into stubbed Next.js pages with accessibility notes.
+    WRITE files using file_writer:
+      - app/(routes)/(home)/page.tsx
+      - app/category/[slug]/page.tsx
+      - app/product/[id]/page.tsx
+      - app/cart/page.tsx
+      - app/checkout/page.tsx
+      - app/order/success/page.tsx
+  expected_output: "TSX pages with idempotent markers and inline comments."
+
+api_and_types:
+  agent: data_modeler
+  async: true
+  description: |
+    Define the basic data layer with types and mocked API routes.
+    WRITE files using file_writer:
+      - app/api/products/route.ts
+      - app/api/products/[id]/route.ts
+      - app/api/cart/route.ts
+      - app/api/checkout/route.ts
+      - types/index.ts
+  expected_output: "Type definitions and API routes."
+
+commerce_flow:
+  agent: commerce_flow_engineer
+  async: true
+  description: |
+    Supply cart and checkout helpers, including a finite state machine.
+    WRITE files using file_writer:
+      - app/components/cart/CartSummary.tsx
+      - app/components/checkout/CheckoutWizard.tsx
+      - app/lib/checkoutMachine.ts
+  expected_output: "Reusable commerce helpers and state machine."
+
+validate_build:
+  agent: qa_validator
+  description: |
+    Describe how to validate the scaffold.
+    Print exact commands and expected results for:
+      pnpm lint
+      pnpm typecheck
+      pnpm build
+  expected_output: "Validation instructions."
+

--- a/src/sprint_3/crew.py
+++ b/src/sprint_3/crew.py
@@ -1,87 +1,92 @@
+"""Builds the Crew responsible for mimicking a target website.
+
+The module reads agent and task definitions from YAML files, wires up shared
+tools such as the ``file_writer`` and ``SerperDevTool``, and exposes a helper
+function :func:`build_crew` that returns a ready-to-run ``Crew`` instance.  The
+crew analyses a target site, scaffolds a Next.js project and finally validates
+the build.
+"""
+
+from __future__ import annotations
+
 import os
-from crewai import LLM
-from crewai import Agent, Crew, Process, Task
-from crewai.project import CrewBase, agent, crew, task
-from crewai.agents.agent_builder.base_agent import BaseAgent
+from pathlib import Path
+from typing import Dict, Any
+
+import yaml
+from crewai import Agent, Crew, LLM, Process, Task
 from crewai_tools import SerperDevTool
-#from .tools.custom_tool import FileCreatorTool
-from typing import List
-# If you want to run a snippet of code before or after the crew starts,
-# you can use the @before_kickoff and @after_kickoff decorators
-# https://docs.crewai.com/concepts/crews#example-crew-class-with-decorators
 
-llm = LLM(
-    model=os.getenv("MODEL"),       # gemini/gemini-2.5-flash
-    api_key=os.getenv("GEMINI_API_KEY"),
-    provider="gemini",
-    temperature=0.6,
-)
+from .tools.file_writer import file_writer
 
-@CrewBase
-class Frontout():
-    """Frontout crew"""
 
-    agents: List[BaseAgent]
-    tasks: List[Task]
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    """Load a YAML configuration file into a Python dictionary."""
 
-    # Learn more about YAML configuration files here:
-    # Agents: https://docs.crewai.com/concepts/agents#yaml-configuration-recommended
-    # Tasks: https://docs.crewai.com/concepts/tasks#yaml-configuration-recommended
-    
-    # If you would like to add tools to your agents, you can learn more about it here:
-    # https://docs.crewai.com/concepts/agents#agent-tools
-    @agent
-    def researcher(self) -> Agent:
-        return Agent(
-            config=self.agents_config['researcher'], # type: ignore[index]
+    with open(path, "r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def build_crew(target_url: str, repo_root: str) -> Crew:
+    """Construct and configure the Sprint 3 crew.
+
+    Parameters
+    ----------
+    target_url:
+        URL of the website whose layout will be mimicked.
+    repo_root:
+        Absolute path to the repository root used by the ``file_writer`` tool.
+    """
+
+    config_dir = Path(__file__).resolve().parent / "config"
+    agents_cfg = _load_yaml(config_dir / "agents.yaml")
+    tasks_cfg = _load_yaml(config_dir / "tasks.yaml")
+
+    # Base LLM configuration shared by all agents.
+    llm = LLM(
+        model=os.getenv("MODEL"),
+        api_key=os.getenv("GEMINI_API_KEY"),
+        provider="gemini",
+        temperature=0.6,
+    )
+
+    # Map simple tool names to actual implementations.
+    tool_registry = {
+        "file_writer": file_writer,
+        "serper": SerperDevTool(),
+    }
+
+    agents: Dict[str, Agent] = {}
+    for name, cfg in agents_cfg.items():
+        tools = [tool_registry[t] for t in cfg.get("tools", [])]
+        agents[name] = Agent(
+            role=cfg["role"],
+            goal=cfg["goal"],
+            backstory=cfg.get("backstory", ""),
+            tools=tools,
+            llm=llm,
             verbose=True,
-            # Setting the LLM to gpt-4o-mini to avoid rate limit errors.
-            llm = llm,
-            tools=[
-                SerperDevTool()
-            ]
         )
 
-    @agent
-    def reporting_analyst(self) -> Agent:
-        return Agent(
-            config=self.agents_config['reporting_analyst'], # type: ignore[index]
-            # Setting the LLM to gpt-4o-mini to avoid rate limit errors.
-            llm = llm,
-            verbose=True
+    tasks = []
+    for name, cfg in tasks_cfg.items():
+        task = Task(
+            description=cfg["description"],
+            agent=agents[cfg["agent"]],
+            expected_output=cfg.get("expected_output"),
+            async_execution=cfg.get("async", False),
         )
+        tasks.append(task)
 
-    # To learn more about structured task outputs,
-    # task dependencies, and task callbacks, check out the documentation:
-    # https://docs.crewai.com/concepts/tasks#overview-of-a-task
-    @task
-    def research_task(self) -> Task:
-        return Task(
-            config=self.tasks_config['research_task'], # type: ignore[index]
-        )
+    crew = Crew(
+        agents=list(agents.values()),
+        tasks=tasks,
+        process=Process.sequential,
+        verbose=True,
+    )
 
-    @task
-    def reporting_task(self) -> Task:
-        return Task(
-            config=self.tasks_config['reporting_task'], # type: ignore[index]
-            output_file='report.md'
-        )
-
-    @crew
-    def crew(self) -> Crew:
-        """Creates the Frontout crew"""
-        # To learn how to add knowledge sources to your crew, check out the documentation:
-        # https://docs.crewai.com/concepts/knowledge#what-is-knowledge
-
-        return Crew(
-            agents=self.agents, # Automatically created by the @agent decorator
-            tasks=self.tasks, # Automatically created by the @task decorator
-            process=Process.sequential,
-            verbose=True,
-            # process=Process.hierarchical, # In case you wanna use that instead https://docs.crewai.com/how-to/Hierarchical/
-        )
+    return crew
 
 
-
-
+__all__ = ["build_crew"]
 

--- a/src/sprint_3/tools/file_writer.py
+++ b/src/sprint_3/tools/file_writer.py
@@ -1,0 +1,51 @@
+"""Utility tool for safely writing files inside the repository.
+
+This module exposes a `file_writer` tool that generation agents can call to
+materialise code on disk.  It enforces a security boundary based on the
+provided repository root so that agents cannot traverse outside of the
+project.  Every write ensures parent directories exist and returns the
+absolute path of the created file.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from crewai_tools import tool
+
+
+@tool("file_writer")
+def file_writer(path: str, content: str, mode: str = "w", repo_root: str = ".") -> str:
+    """Persist ``content`` to ``path`` relative to ``repo_root``.
+
+    Args:
+        path: Destination file path relative to ``repo_root``.
+        content: Textual data that will be written to the file.
+        mode: File open mode, defaults to ``"w"`` to overwrite existing files.
+        repo_root: Root directory that acts as a sandbox for writes.
+
+    Returns:
+        The absolute path of the written file.
+
+    Raises:
+        ValueError: If the resolved destination escapes ``repo_root``.
+    """
+
+    root = Path(repo_root).resolve()
+    destination = (root / path).resolve()
+
+    # Guard against directory traversal outside of ``repo_root``.
+    if not str(destination).startswith(str(root)):
+        raise ValueError("Attempted write outside repo_root")
+
+    # Ensure parent directories exist before writing.
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write the file using the requested mode.
+    with open(destination, mode, encoding="utf-8") as handle:
+        handle.write(content)
+
+    return str(destination)
+
+
+__all__ = ["file_writer"]
+


### PR DESCRIPTION
## Summary
- add secure file_writer tool for agents to persist generated code
- define agents and tasks for analyzing a site and scaffolding a Next.js app
- implement crew builder and CLI runner for Sprint 3 website mimicker

## Testing
- `python -m py_compile src/sprint_3/tools/file_writer.py src/sprint_3/crew.py src/sprint_3/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0dbbdae448326b948b3855b1cbed6